### PR TITLE
rnnoise before deepspeech

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,24 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "deepspeech"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "deepspeech-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "deepspeech-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +282,7 @@ name = "rnnoise-c"
 version = "0.1.0"
 dependencies = [
  "audrey 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deepspeech 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hound 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rnnoise-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -430,6 +449,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum claxon 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f86c952727a495bda7abaf09bafdee1a939194dd793d9a8e26281df55ac43b00"
+"checksum deepspeech 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7589819319a3f33b29ef147dcd2fcfb8e128882b8407b8ecebb3b3fd5da687d"
+"checksum deepspeech-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9477201ef87e30be6cf343b522bdc7ac71e7bf48ad7b2a13a411e64b25163722"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ readme = "README.md"
 
 [dev-dependencies]
 audrey = "0.2"
-structopt = "0.3.8"
+deepspeech = "0.6"
 hound = "3.4"
+structopt = "0.3.8"
 
 [dependencies]
 #rnnoise-sys = { path = "sys" }

--- a/examples/deepspeech.rs
+++ b/examples/deepspeech.rs
@@ -1,0 +1,156 @@
+// In order to compile and use this example you must first follow the
+// preparation directions on https://github.com/RustAudio/deepspeech-rs
+
+extern crate audrey;
+extern crate deepspeech;
+extern crate hound;
+extern crate rnnoise_c;
+extern crate structopt;
+
+use std::fs::File;
+use std::path::Path;
+
+use audrey::read::Reader;
+use audrey::sample::interpolate::{Converter, Linear};
+use audrey::sample::signal::{from_iter, Signal};
+use deepspeech::Model;
+use rnnoise_c::{DenoiseState, FRAME_SIZE};
+use structopt::StructOpt;
+
+// RNNoise assumes audio is 16-bit mono with a 48 KHz sample rate
+const RNNOISE_SAMPLE_RATE :u32 = 48_000;
+
+// The DeepSpeech model has been trained on 16 KHz
+const DEEPSPEECH_SAMPLE_RATE :u32 = 16_000;
+
+// Deepspeech constants
+const BEAM_WIDTH :u16 = 500;
+const LM_WEIGHT :f32 = 0.75;
+const VALID_WORD_COUNT_WEIGHT :f32 = 1.85;
+
+#[derive(StructOpt, Debug, Clone)]
+#[structopt(name = "client")]
+pub struct Configuration {
+    /// Verbose mode
+    #[structopt(short, long)]
+    verbose: bool,
+    /// Input audio file
+    #[structopt(short, long, required=true)]
+    input: String,
+    /// Output audio file
+    #[structopt(short, long, required=true)]
+    output: String,
+    /// Deepspeech model directory
+    #[structopt(short, long, required=true)]
+    model: String,
+}
+
+fn main() {
+    let configuration = Configuration::from_args();
+    if configuration.verbose {
+        println!("Configuration: {:?}", configuration);
+    }
+
+    // Load input audio file
+    let audio_file = File::open(&configuration.input).unwrap();
+    let mut reader = Reader::new(audio_file).unwrap();
+    let desc = reader.description();
+    if configuration.verbose {
+        println!("description: {:?}", &desc);
+    }
+    assert_eq!(1, desc.channel_count(),
+        "The channel count is required to be one, at least for now");
+
+    // Obtain the buffer of samples
+    let mut audio_buf :Vec<_> = if desc.sample_rate() == RNNOISE_SAMPLE_RATE {
+        reader.samples::<f32>().map(|s| s.unwrap()).collect()
+    } else {
+        // We need to interpolate to the target sample rate
+        let interpolator = Linear::new([0f32], [0.0]);
+        let conv = Converter::from_hz_to_hz(
+            from_iter(reader.samples::<f32>().map(|s| [s.unwrap()])),
+            interpolator,
+            desc.sample_rate() as f64,
+            RNNOISE_SAMPLE_RATE as f64);
+        conv.until_exhausted().map(|v| v[0]).collect()
+    };
+
+    if configuration.verbose {
+        println!("{} length: {}", &configuration.input, audio_buf.len());
+    }
+
+    // The library requires each frame be exactly FRAME_SIZE, so we append
+    // some zeros to be sure the final frame is sufficiently long.
+    let padding = audio_buf.len() % FRAME_SIZE;
+    if padding > 0 {
+        let mut pad: Vec<f32> = vec![0.0; FRAME_SIZE - padding];
+        audio_buf.append(&mut pad);
+        if configuration.verbose {
+            println!("padded audio file with {} characters", padding);
+        }
+    }
+    let mut denoised_buffer: Vec<f32> = vec![];
+    let mut rnnoise = DenoiseState::new();
+    let mut denoised_chunk: Vec<f32> = vec![0.0; FRAME_SIZE];
+    let buffers = audio_buf[..].chunks(FRAME_SIZE);
+    for buffer in buffers {
+        rnnoise.process_frame_mut(&buffer, &mut denoised_chunk[..]);
+        denoised_buffer.extend_from_slice(&mut denoised_chunk);
+    }
+
+    if configuration.verbose {
+        println!("{} length: {}", &configuration.output, denoised_buffer.len());
+    }
+    assert_eq!(audio_buf.len(), denoised_buffer.len());
+
+    // Write denoised buffer into output file
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: RNNOISE_SAMPLE_RATE,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+    let opt_wav_writer = hound::WavWriter::create(&configuration.output, spec);
+    let mut wav_writer = opt_wav_writer.expect("failed to create wav file");
+    denoised_buffer.iter().for_each(|i| wav_writer.write_sample(*i).expect("failed to write to wav file"));
+    wav_writer.finalize().unwrap();
+
+    // Set up DeepSpeech model
+    let dir_path = Path::new(&configuration.model);
+    let mut m = Model::load_from_files(
+        &dir_path.join("output_graph.pb"),
+        BEAM_WIDTH).unwrap();
+    m.enable_decoder_with_lm(
+        &dir_path.join("lm.binary"),
+        &dir_path.join("trie"),
+        LM_WEIGHT,
+        VALID_WORD_COUNT_WEIGHT);
+
+    // Use denoised audio file with Deepspeech
+    let denoised_audio_file = File::open(&configuration.output).unwrap();
+    let mut denoised_reader = Reader::new(denoised_audio_file).unwrap();
+    let denoised_desc = denoised_reader.description();
+    if configuration.verbose {
+        println!("denoised description: {:?}", &denoised_desc);
+    }
+    assert_eq!(1, denoised_desc.channel_count(),
+        "The channel count is required to be one, at least for now");
+
+    // Obtain the buffer of samples
+    let denoised_audio_buf :Vec<_> = {
+        // We need to interpolate to the target sample rate
+        let interpolator = Linear::new([0i16], [0]);
+        let conv = Converter::from_hz_to_hz(
+            from_iter(denoised_reader.samples::<i16>().map(|s| [s.unwrap()])),
+            interpolator,
+            denoised_desc.sample_rate() as f64,
+            DEEPSPEECH_SAMPLE_RATE as f64);
+        conv.until_exhausted().map(|v| v[0]).collect()
+    };
+
+    // Run the speech to text algorithm
+    let result = m.speech_to_text(&denoised_audio_buf).unwrap();
+
+    // Output the result
+    println!("{}", result);
+}


### PR DESCRIPTION
I'm trying to run rnnoise prior to converting audio to text with deepspeech. So far the only way I've made it happen successfully is to write out the denoised wav file, then reload that with deepspeech -- see the included example.

Can you recommend a cleaner way to do this? It seems I should be able to load the raw denoised audio into deepspeech, but I've not been able to make this work.