### PR TITLE
Add process_frame_in_place method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ impl DenoiseState {
 		};
 		Self(ds)
 	}
+
 	/// Performs denoising operations on `in_data` array into `out_data`
 	///
 	/// Panics if the passed slices are not equal to `FRAME_SIZE`.
@@ -29,6 +30,23 @@ impl DenoiseState {
 			let out_ptr = out_data.as_mut_ptr();
 			let in_ptr = in_data.as_ptr();
 			sys::rnnoise_process_frame(self.0, out_ptr, in_ptr)
+		}
+	}
+
+	/// Performs denoising operations on `in_data` array into `out_data`
+	///
+	/// Panics if the passed slices are not equal to `FRAME_SIZE`.
+	/// Assumes input data is mono 16 bit audio encoded at a sample rate of 48 kHz.
+	///
+	/// Note that the input floats should be in amplitude ranges between
+	/// -32767.0 and 32767.0, instead of the more common -1.0 and 1.0
+	/// boundaries. The output will be scaled in a similar fashion.
+	pub fn process_frame_in_place(&mut self, data: &mut [f32])  -> f32 {
+		assert_eq!(data.len(), FRAME_SIZE);
+
+		unsafe {
+			let ptr = data.as_mut_ptr();
+			sys::rnnoise_process_frame(self.0, ptr, ptr)
 		}
 	}
 }


### PR DESCRIPTION
The C rnnoise example also transforms the data in place, so this should be safe.