### PR TITLE
Mark DenoiseState as Send

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub struct DenoiseState(* mut sys::DenoiseState);
 
 pub const FRAME_SIZE :usize = 480;
 
+unsafe impl Send for DenoiseState {}
+
 impl DenoiseState {
 	pub fn new() -> Self {
 		let ds = unsafe {


### PR DESCRIPTION
There is no global state, so sending it between threads should be fine.
Fixes #8